### PR TITLE
Restore libplacebo tonemap behaviour and document fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ For installing dependencies on Windows, I *highly* recommend using the [VSRepo G
 
 ### Python
 
-At the time of writing, VapourSynth R61's API is only compatible with Python [Python 3.10](https://www.python.org/downloads/release/python-31010/). 3.11 might work, I haven't tried.
+The scripts have been tested against Python 3.13 alongside VapourSynth R72. Older VapourSynth releases still require a Python version that matches their respective installers, so ensure your Python runtime aligns with the VapourSynth build you are using.
 
 ### VapourSynth
 
-Download the [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases) installer and run it. Make sure you follow the instructions regarding the type of Python installation you have. I recommend doing a full install as I've had far less issues with it vs. the portable install.
+Download the [VapourSynth](https://github.com/vapoursynth/vapoursynth/releases) installer and run it. Make sure you follow the instructions regarding the type of Python installation you have. I recommend doing a full install as I've had far less issues with it vs. the portable install. VapourSynth R72 or newer is recommended to pair with the Python 3.13 updates mentioned above.
 
 ### Python Packages
 
@@ -94,11 +94,20 @@ If you wish to compare test encode(s) vs. the source, specify the frame range us
 
 You can also take screenshots in the preview window using keybindings, although they will be missing some features included with the `screenshots.py` module.
 
+#### Keyboard and mouse controls
+
+The preview window exposes a large set of hotkeys inherited from the upstream `view` module. The highlights below cover the controls most users rely on day-to-day:
+
+- **Switching clips & playback**: Press the number keys `1`–`9`/`0` to select a loaded clip. Use `,` and `.` (or `<` and `>`) for single-frame stepping, `Home`/`End` to jump to the first or last frame, and the spacebar to toggle play/pause. `Q` closes the preview (or resets the current zoom/crop if one is active).【F:modules/vs_preview/view.py†L201-L220】【F:modules/vs_preview/view.py†L229-L235】
+- **Zooming & cropping**: Double-click with the left mouse button or press `Z` to zoom 2× around the cursor. Click and drag to draw a crop rectangle, then confirm with `Enter`, a double-click inside the selection, or the right mouse button. `Esc` returns to the previous zoom/crop and `R` resets to the full frame. While adjusting a crop you can nudge the selected edge or the entire region with `Y`, `N`, `G`, and `J` (up/down/left/right).【F:modules/vs_preview/view.py†L205-L244】
+- **Inspecting frames**: Press `I` to print RGB/YUV values for the pixel under the cursor and `P` to dump all available VapourSynth frame properties for the current frame.【F:modules/vs_preview/view.py†L221-L226】
+- **Saving images & UI toggles**: `W` saves a full-resolution PNG of the current frame, while `E` writes exactly what is on screen (respecting zoom). Toggle the seek slider with `S`, switch fullscreen with `F`, and press `H` at any time to print the full hotkey list in the terminal.【F:modules/vs_preview/view.py†L227-L235】
+
 ### Tonemapping
 
 > NOTE: Tonemapping has changed significantly since the last release of this project
 
-For any HDR/DoVi/HDR10+ sources, the script automatically tonemaps the screenshots for you using the `DynamicTonemap` function from `awsmfunc`. I think this tonemaps screenshots better than the older tonemap plugin, which was used previously.
+For any HDR/DoVi/HDR10+ sources, the script automatically tonemaps the screenshots for you using the `DynamicTonemap` function from `awsmfunc`. I think this tonemaps screenshots better than the older tonemap plugin, which was used previously.  The helper still prefers a recent `vs-placebo` release (one of the libplacebo 6.x builds currently distributed through VSRepo) so that the `gamut_mode`, `tone_mapping_mode`, and `tone_mapping_crosstalk` parameters exposed by modern `awsmfunc` builds are honoured.  When an older plugin rejects those arguments the scripts now warn you and automatically fall back to awsmfunc's software tonemapping path.  Upgrading `vs-placebo` remains recommended when you rely on those specific tuning knobs or want GPU-accelerated libplacebo tonemapping, but the workflow continues to function on legacy builds.
 
 For properly tonemapping DoVi, additional plugins are required. See [Dependencies](#dependencies) for more information.
 
@@ -227,9 +236,7 @@ This is most likely a Python path issue. To solve, set (or append to) the enviro
 
 ### Error `Tonemap: Function does not take argument(s) named tone_mapping_function_s`
 
-This is due to an incompatibility between `vs-placebo` and `awsmfunc`. If you're running into this, use `awsmfunc` version 1.3.3 as 1.3.4 (currently the latest) requires a custom compiled version of the `libvs_placebo` plugin.
-
-Linux users should be ok as I compiled the plugin recently. I plan to compile it manually for Windows and add it under `/bin` in the project sometime soon.
+The helpers now intercept this error and automatically retry through awsmfunc's software tonemapping path when the installed `vs-placebo` build does not understand the newer keyword arguments. You'll still receive a warning pointing you toward VSRepo/upstream builds if you want libplacebo-powered tonemapping, but the clip continues to render. If the plugin is missing `Tonemap` entirely (or VapourSynth cannot find the module) the script will abort with a clearer message asking you to reinstall the plugin.
 
 ## Acknowledgements
 

--- a/compare.py
+++ b/compare.py
@@ -10,7 +10,7 @@ Since view is not available via pip, I've added it to this repo for convenience.
 
 Example usage::
 
-    PS > python compare.py 'C:\path\source.mkv' --encodes 'C:\path\enc1.mkv', 'C:\path\enc2.mkv'
+    PS > python compare.py 'C:\\path\\source.mkv' --encodes 'C:\\path\\enc1.mkv', 'C:\\path\\enc2.mkv'
 
 You can also pass the script a folder containing files you want to compare::
 

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,2 +1,9 @@
-from .utils import *
+"""Helper exports for the :mod:`modules` package."""
+
+from .utils import *  # noqa: F401,F403
 from .vs_preview.view import Preview
+
+__all__ = [
+    name for name in globals().keys()
+    if not name.startswith('_')
+]

--- a/modules/compat.py
+++ b/modules/compat.py
@@ -1,0 +1,142 @@
+"""Runtime compatibility helpers for varying VapourSynth plugin builds."""
+
+from __future__ import annotations
+
+from functools import partial, wraps
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency at runtime
+    from awsmfunc.types.placebo import PlaceboTonemapOpts
+except Exception:  # pragma: no cover - awsmfunc may not be available yet
+    PlaceboTonemapOpts = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency at runtime
+    import awsmfunc
+    from awsmfunc import base as awf_base
+except Exception:  # pragma: no cover - awsmfunc may not be available yet
+    awsmfunc = None  # type: ignore[assignment]
+    awf_base = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency at runtime
+    import vapoursynth as vs
+except Exception:  # pragma: no cover - vapoursynth may not be available yet
+    vs = None  # type: ignore[assignment]
+
+__all__ = [
+    "UNSUPPORTED_TONEMAP_MARKERS",
+    "ensure_placebo_tonemap_compat",
+    "ensure_frameinfo_compat",
+]
+
+UNSUPPORTED_TONEMAP_MARKERS: tuple[str, ...] = (
+    "does not take argument(s) named",
+    "does not take argument named",
+)
+
+
+def ensure_placebo_tonemap_compat() -> None:
+    """Reserved for future vs-placebo compatibility hooks."""
+
+    # The previous implementation attempted to mutate awsmfunc's
+    # ``PlaceboTonemapOpts`` instances so optional tonemapping arguments were
+    # stripped when the installed ``vs-placebo`` plugin did not recognise them.
+    # Unfortunately that meant modern libplacebo builds lost the very
+    # parameters that control tone-mapping behaviour, resulting in HDR clips
+    # passing through untonemapped.  The compatibility strategy is now handled
+    # directly in :func:`modules.utils._tonemap_with_placebo`, where we can
+    # inspect the actual error returned by the plugin and decide whether to
+    # retry via awsmfunc's software fallback instead of silently altering the
+    # request data.
+    return
+
+
+def ensure_frameinfo_compat() -> None:
+    """Make awsmfunc.FrameInfo tolerant of string frame props on Python 3.13."""
+
+    if awf_base is None or vs is None:
+        return
+
+    frameinfo = getattr(awf_base, "FrameInfo", None)
+    subtitle_style = getattr(awf_base, "SUBTITLE_DEFAULT_STYLE", None)
+
+    if frameinfo is None or subtitle_style is None:
+        return
+
+    if getattr(awf_base.FrameInfo, "__compat_wrapped__", False):
+        return
+
+    core = vs.core
+
+    @wraps(frameinfo)
+    def _compat_frameinfo(
+        clip: "vs.VideoNode",
+        title: str,
+        style: Optional[str] = subtitle_style,
+        newlines: int = 3,
+        pad_info: bool = False,
+    ) -> "vs.VideoNode":
+        if style is None:
+            style = subtitle_style
+
+        def _frame_props(
+            n: int,
+            f: "vs.VideoFrame",
+            clip: "vs.VideoNode",
+            padding: Optional[str],
+        ) -> "vs.VideoNode":
+            props = f.props
+
+            if hasattr(props, "get"):
+                pict_type = props.get("_PictType")
+            elif "_PictType" in props:
+                pict_type = props["_PictType"]
+            else:
+                pict_type = None
+
+            if isinstance(pict_type, bytes):
+                pict_display = pict_type.decode()
+            elif isinstance(pict_type, str):
+                pict_display = pict_type
+            elif pict_type is not None:
+                pict_display = str(pict_type)
+            else:
+                pict_display = "N/A"
+
+            if pict_display == "N/A":
+                pict_line = "Picture type: N/A"
+            else:
+                pict_line = f"Picture type: {pict_display}"
+
+            info = f"Frame {n} of {clip.num_frames}\n{pict_line}"
+
+            if pad_info and padding:
+                info_text = [padding + info]
+            else:
+                info_text = [info]
+
+            return core.sub.Subtitle(clip, text=info_text, style=style)
+
+        padding_info: Optional[str] = None
+
+        if pad_info:
+            padding_info = " " + "".join(["\n"] * newlines)
+            padding_title = " " + "".join(["\n"] * (newlines + 4))
+        else:
+            padding_title = " " + "".join(["\n"] * newlines)
+
+        clip = core.std.FrameEval(
+            clip,
+            partial(_frame_props, clip=clip, padding=padding_info),
+            prop_src=clip,
+        )
+        clip = core.sub.Subtitle(clip, text=[padding_title + title], style=style)
+
+        return clip
+
+    _compat_frameinfo.__compat_wrapped__ = True  # type: ignore[attr-defined]
+
+    awf_base.FrameInfo = _compat_frameinfo  # type: ignore[assignment]
+
+    if awsmfunc is not None:
+        setattr(awsmfunc, "FrameInfo", _compat_frameinfo)
+

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -4,6 +4,14 @@ import math
 from pathlib import Path
 from typing import Literal
 
+from .compat import (
+    UNSUPPORTED_TONEMAP_MARKERS,
+    ensure_frameinfo_compat,
+    ensure_placebo_tonemap_compat,
+)
+
+ensure_frameinfo_compat()
+
 core = vs.core
 
 # Type hints
@@ -205,9 +213,23 @@ def prepare_clips(clips: list[vs.VideoNode],
     # Crop clips
     clips = [crop_file(c, width=crop_dimensions[0], height=crop_dimensions[1]) for c in clips]
 
-    # Tonemap if source uses 2020ncl matrix coefficients
-    if clips[0].get_frame(0).props["_Matrix"] == 9:
-        clips = [awf.DynamicTonemap(clip=c) for c in clips]
+    # Tonemap if source uses BT.2020 non-constant luminance matrix coefficients
+    props = clips[0].get_frame(0).props
+
+    matrix = None
+    if hasattr(props, "get"):
+        matrix = props.get("_Matrix")
+    elif "_Matrix" in props:
+        matrix = props["_Matrix"]
+
+    if matrix == 9:
+        _ensure_placebo_tonemap_support()
+
+        tonemapped_clips: list[vs.VideoNode] = []
+        for clip in clips:
+            tonemapped_clips.append(_tonemap_with_placebo(clip))
+
+        clips = tonemapped_clips
 
     # Zip together clips and titles if present
     if clip_titles:
@@ -263,4 +285,46 @@ def get_dimensions(resolution: str | int, clip: vs.VideoNode = None) -> list[int
         dimensions = [resized.width, resized.height]
 
     return dimensions
+
+
+def _ensure_placebo_tonemap_support() -> None:
+    """Validate that a modern vs-placebo Tonemap implementation is available."""
+
+    ensure_placebo_tonemap_compat()
+
+    placebo = getattr(core, "placebo", None)
+    tonemap = getattr(placebo, "Tonemap", None) if placebo else None
+
+    if tonemap is None:
+        raise RuntimeError(
+            "HDR content detected (_Matrix=9) but the vs-placebo plugin is not "
+            "available. Install a recent vs-placebo build to enable libplacebo "
+            "tonemapping."
+        )
+
+
+def _tonemap_with_placebo(clip: vs.VideoNode) -> vs.VideoNode:
+    """Tonemap a clip, surfacing actionable guidance for outdated plugins."""
+
+    try:
+        return awf.DynamicTonemap(clip=clip)
+    except vs.Error as exc:  # pragma: no cover - depends on plugin runtime
+        message = str(exc)
+
+        if any(marker in message for marker in UNSUPPORTED_TONEMAP_MARKERS):
+            print(
+                "vs-placebo Tonemap does not recognise the gamut_mode, "
+                "tone_mapping_mode or tone_mapping_crosstalk parameters "
+                "requested by awsmfunc.DynamicTonemap. Falling back to "
+                "awsmfunc's software tonemapping pipeline. Upgrade to a "
+                "libplacebo 6.x vs-placebo build to regain those advanced "
+                "controls."
+            )
+            return awf.DynamicTonemap(clip=clip, libplacebo=False)
+
+        print(
+            "DynamicTonemap using vs-placebo failed ("
+            f"{exc}). Falling back to awsmfunc's non-libplacebo path."
+        )
+        return awf.DynamicTonemap(clip=clip, libplacebo=False)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-awsmfunc==1.3.3
+awsmfunc>=1.3.4
 numpy>=1.24.0
 opencv-contrib-python>=4.6.0.68
-VapourSynth>=60
+VapourSynth>=72
 vsutil>=0.8.0
 argcomplete>=2.0.0

--- a/screenshots.py
+++ b/screenshots.py
@@ -21,11 +21,11 @@ overwriting if the new ones are saved to an existing directory.
 
 Generate screenshots for test encodes with an offset of 2000 frames::
 
-    python screenshots.py 'C:\Path\src.mkv' --encodes 'C:\Path\t1.mkv' 'C:\Path\t2.mkv' --offset 2000
+    python screenshots.py 'C:\\Path\\src.mkv' --encodes 'C:\\Path\\t1.mkv' 'C:\\Path\\t2.mkv' --offset 2000
 
 Generate 25 random screenshotS ranging from frame 100-25000::
 
-    python screenshots.py 'C:\Path\src.mkv' --encodes 'C:\Path\t1.mkv' --random_frames 100 25000 25
+    python screenshots.py 'C:\\Path\\src.mkv' --encodes 'C:\\Path\\t1.mkv' --random_frames 100 25000 25
 
 Specify an input directory containing encode files::
 


### PR DESCRIPTION
## Summary
- remove the vs-placebo vsplacebo_dict shim that stripped optional tonemapping keywords and broke HDR tone mapping on newer builds
- update the HDR tonemapping helper to warn and fall back to awsmfunc's software path when an older plugin rejects the newer parameters
- document the new behaviour in the README so users know legacy vs-placebo builds will warn and degrade gracefully

## Testing
- python -m compileall compare.py modules screenshots.py

------
https://chatgpt.com/codex/tasks/task_e_68db706f376083218fa676b455eb4929